### PR TITLE
feat(ethereum): 添加EIP-159 gas价格计算支持

### DIFF
--- a/src-tauri/src/database/chain_service.rs
+++ b/src-tauri/src/database/chain_service.rs
@@ -363,6 +363,7 @@ impl<'a> ChainService<'a> {
     }
 
     /// 根据链key和token_key获取代币的decimals配置
+    #[allow(dead_code)]
     pub async fn get_token_decimals_by_key(&self, chain_key: &str, token_key: &str) -> Result<Option<i32>> {
         let decimals = sqlx::query_scalar::<_, i32>(
             r#"


### PR DESCRIPTION
- 新增 get_base_fee 方法获取当前网络的基础费用
- 在 transfer.rs 中实现基于 baseFee 的 gas price 最小值校验逻辑
- 区分 Arbitrum 和其他链的不同 gas price 安全边际策略
- 优化 gas price 类型匹配逻辑并增强错误处理
- 增加调试日志以便追踪 gas price 计算过程
- 保留 get_block_gas_limit 方法用于获取区块 Gas Limit
- 添加 dead_code 属性忽略未使用的数据库方法警告